### PR TITLE
Go task: download and install a go version

### DIFF
--- a/pkg/features/golang.go
+++ b/pkg/features/golang.go
@@ -1,0 +1,44 @@
+package features
+
+import (
+	"github.com/pior/dad/pkg/config"
+	"github.com/pior/dad/pkg/helpers"
+	"github.com/pior/dad/pkg/project"
+)
+
+func init() {
+	allFeatures["golang"] = NewGolang
+}
+
+type Golang struct {
+	version string
+}
+
+func NewGolang(param string) Feature {
+	return &Golang{version: param}
+}
+
+func (g *Golang) Enable(cfg *config.Config, proj *project.Project, env *Env) error {
+	golang := helpers.NewGolang(cfg, g.version)
+
+	if !golang.Exists() {
+		return DevUpNeeded
+	}
+
+	env.PrependToPath(golang.BinPath())
+
+	env.Set("GOROOT", golang.Path())
+
+	// TODO: decide whether we want to enable GO15VENDOREXPERIMENT
+	// Introduced in 1.5, enabled by default in 1.7
+
+	return nil
+}
+
+func (g *Golang) Disable(cfg *config.Config, env *Env) {
+	// Golang install without version to get the base path
+	golang := helpers.NewGolang(cfg, "")
+	env.RemoveFromPath(golang.Path())
+
+	env.Unset("GOROOT")
+}

--- a/pkg/helpers/golang.go
+++ b/pkg/helpers/golang.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/pior/dad/pkg/config"
 	"github.com/pior/dad/pkg/executor"
@@ -21,6 +22,14 @@ func NewGolang(cfg *config.Config, version string) *Golang {
 
 func (g *Golang) Exists() bool {
 	return utils.PathExists(g.path)
+}
+
+func (g *Golang) Path() string {
+	return g.path
+}
+
+func (g *Golang) BinPath() string {
+	return path.Join(g.path, "bin")
 }
 
 func (g *Golang) Install() (err error) {

--- a/pkg/helpers/golang.go
+++ b/pkg/helpers/golang.go
@@ -1,0 +1,39 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pior/dad/pkg/config"
+	"github.com/pior/dad/pkg/executor"
+	"github.com/pior/dad/pkg/utils"
+)
+
+type Golang struct {
+	version string
+	path    string
+}
+
+func NewGolang(cfg *config.Config, version string) *Golang {
+	path := cfg.DataDir("golang", version)
+	return &Golang{version: version, path: path}
+}
+
+func (g *Golang) Exists() bool {
+	return utils.PathExists(g.path)
+}
+
+func (g *Golang) Install() (err error) {
+	err = os.MkdirAll(g.path, 0750)
+	if err != nil {
+		return
+	}
+
+	os := "darwin"
+	arch := "amd64"
+	url := fmt.Sprintf("https://dl.google.com/go/go%s.%s-%s.tar.gz", g.version, os, arch)
+	cmdline := fmt.Sprintf("curl -sL %s | tar --strip 1 -xzC %s", url, g.path)
+	_, err = executor.RunShell(cmdline)
+
+	return
+}

--- a/pkg/tasks/golang.go
+++ b/pkg/tasks/golang.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"github.com/pior/dad/pkg/helpers"
+	"github.com/pior/dad/pkg/project"
 )
 
 func init() {
@@ -50,4 +51,8 @@ func (g *Golang) Perform(ctx *Context) (err error) {
 
 	ctx.ui.TaskActed()
 	return nil
+}
+
+func (g *Golang) Feature(proj *project.Project) (string, string) {
+	return "golang", g.version
 }

--- a/pkg/tasks/golang.go
+++ b/pkg/tasks/golang.go
@@ -1,0 +1,53 @@
+package tasks
+
+import (
+	"github.com/pior/dad/pkg/helpers"
+)
+
+func init() {
+	allTasks["go"] = NewGolang
+}
+
+type Golang struct {
+	version string
+}
+
+func NewGolang() Task {
+	return &Golang{}
+}
+
+func (g *Golang) Load(definition interface{}) (bool, error) {
+	def, ok := definition.(map[interface{}]interface{})
+	if !ok {
+		return false, nil
+	}
+	if version, ok := def["go"]; ok {
+		g.version, ok = version.(string)
+		if !ok {
+			return false, nil
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (g *Golang) Perform(ctx *Context) (err error) {
+	ctx.ui.TaskHeader("Golang", g.version)
+
+	goSrc := helpers.NewGolang(ctx.cfg, g.version)
+
+	if goSrc.Exists() {
+		ctx.ui.TaskAlreadyOk()
+		return nil
+	}
+
+	err = goSrc.Install()
+	if err != nil {
+		ctx.ui.TaskError(err)
+		return err
+	}
+
+	ctx.ui.TaskActed()
+	return nil
+}

--- a/pkg/tasks/golang.go
+++ b/pkg/tasks/golang.go
@@ -1,6 +1,8 @@
 package tasks
 
 import (
+	"os"
+
 	"github.com/pior/dad/pkg/helpers"
 	"github.com/pior/dad/pkg/project"
 )
@@ -37,6 +39,10 @@ func (g *Golang) Perform(ctx *Context) (err error) {
 	ctx.ui.TaskHeader("Golang", g.version)
 
 	goSrc := helpers.NewGolang(ctx.cfg, g.version)
+
+	if os.Getenv("GOPATH") == "" {
+		ctx.ui.TaskWarning("The GOPATH environment variable should be set to ~/")
+	}
 
 	if goSrc.Exists() {
 		ctx.ui.TaskAlreadyOk()

--- a/pkg/termui/ui.go
+++ b/pkg/termui/ui.go
@@ -41,6 +41,10 @@ func (u *UI) TaskError(err error) {
 	fmt.Fprintf(u.out, "  %s\n", color.Red(err.Error()))
 }
 
+func (u *UI) TaskWarning(message string) {
+	fmt.Fprintf(u.out, "  Warning: %s\n", color.Brown(message))
+}
+
 func (u *UI) ProjectExists() {
 	fmt.Fprintf(u.out, "🐼  %s\n", color.Brown("project already exists locally"))
 }


### PR DESCRIPTION
Add support for Go with a `go` task:

```yaml
up:
  - go: 1.9.5
```

Task:
- Download and install the go distribution in `<DATADIR>/golang/<VERSION>`
- Warn the user if `GOPATH` is not set

Env:
- Set the `GOROOT` envvar
- Append the `PATH` with `<DATADIR>/golang/<VERSION>/bin`

Not sure what to do about [`GO15VENDOREXPERIMENT`](https://github.com/pior/dad/pull/26/files#diff-81ffd0a250e5a13fa3eb05339dd137b5R32)

Ping @mlhamel