### PR TITLE
Add a shell linter command

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,6 +3,9 @@ up:
   - custom:
       met?: dep status 2> /dev/null > /dev/null
       meet: dep ensure
+  - custom:
+      met?: test -e /usr/local/Cellar/shellcheck
+      meet: brew install shellcheck
 
 commands:
   testup:
@@ -20,6 +23,10 @@ commands:
   lint:
     desc: Lint the project
     run: script/lint
+
+  lint-shell:
+    desc: Lint the shell scripts
+    run: shellcheck script/* tests/*.sh
 
   ci:
     desc: Run all tests as CI would do

--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
-#!/bin/sh
-set -eu
+#!/usr/bin/env bash
+set -euo pipefail
 
 go test `go list ./... | grep -vF /vendor/`


### PR DESCRIPTION
The output of `shellcheck` is not really usable as CI check since the line between acceptable and harmful is often hard to draw with shell scripts.

But by making the command very accessible, we can still improve the quality of those scripts. 