### PR TITLE
Run integration tests on Zsh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ go:
 
 go_import_path: github.com/pior/dad
 
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq zsh
+
 install:
   - script/setup-ci test
 

--- a/script/integration_test
+++ b/script/integration_test
@@ -1,34 +1,58 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-ROOT=$PWD
-export PATH=$ROOT:$PATH
+setup_environment() {
+    echo " -> Build the project."
+    go build
 
-go build
+    echo " -> Adding the current dir to PATH."
+    ROOT=$PWD
+    export PATH="$ROOT:$PATH"
 
-if [[ "$(which dad)" != "$ROOT/dad" ]]; then
-    echo "In order to run the integration test on the current code,"
-    echo "the locally built dad binary must be found in the PATH."
-    echo "But 'which dad' returned: $(which dad)"
-    exit 1
-fi
-
-RC=0
-
-cd $ROOT/tests
-TESTS=*_test.sh
-for testfile in $TESTS; do
-    echo -e "\nTest file: $testfile"
-    ./$testfile
-
-    if [[ $? != 0 ]]; then
-        RC=1
+    if [[ "$(which dad)" != "$ROOT/dad" ]]; then
+        echo "In order to run the integration test on the current code,"
+        echo "the locally built dad binary must be found in the PATH."
+        echo "But 'which dad' returned: $(which dad)"
+        exit 1
     fi
-done
+}
 
-if [[ $RC == 0 ]]; then
-    echo -e "\nAll tests passed successfully"
-else
-    echo -e "\nError: At least one test failed!"
-fi
+run_tests() {
+    local failures=()
+    local readonly shell=$1
 
-exit $RC
+    echo -e "\n\n#--------------------------------------------"
+    echo -e "# Running tests with $shell"
+    echo -e "#"
+
+    for testfile in *_test.sh; do
+        echo -e "\nRunning: ${testfile}"
+        $shell ${testfile} || failures+=(${testfile})
+    done
+
+    if [[ ${#failures[@]} -ne 0 ]]; then
+        echo -e "\n\n#--------------------------------------------"
+        echo -e "\n\REPORT: the following tests failed! ❌"
+        for failure in "${failures[@]}"; do
+            echo "Failed: $failure -> ❌"
+        done
+        return 1
+    fi
+
+    echo -e "\nAll tests passed successfully: ✅"
+}
+
+main() {
+    setup_environment
+
+    cd $ROOT/tests
+
+    local exitcode=0
+
+    run_tests "bash" || exitcode=1
+    run_tests "zsh -o shwordsplit" || exitcode=1
+
+    exit $exitcode
+}
+
+main

--- a/script/integration_test
+++ b/script/integration_test
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+title() {
+    echo -e "\n\n#--------------------------------------------"
+    echo -e "# $@"
+    echo -e "#"
+}
+
 setup_environment() {
     echo " -> Build the project."
     go build
@@ -19,11 +25,9 @@ setup_environment() {
 
 run_tests() {
     local failures=()
-    local readonly shell=$1
+    local -r shell=$1
 
-    echo -e "\n\n#--------------------------------------------"
-    echo -e "# Running tests with $shell"
-    echo -e "#"
+    title "Running tests with $shell"
 
     for testfile in *_test.sh; do
         echo -e "\nRunning: ${testfile}"
@@ -31,10 +35,10 @@ run_tests() {
     done
 
     if [[ ${#failures[@]} -ne 0 ]]; then
-        echo -e "\n\n#--------------------------------------------"
-        echo -e "\n\REPORT: the following tests failed! ❌"
+        title "REPORT: the following tests failed! ❌"
+
         for failure in "${failures[@]}"; do
-            echo "Failed: $failure -> ❌"
+            echo "Failed: $failure ❌"
         done
         return 1
     fi
@@ -45,7 +49,7 @@ run_tests() {
 main() {
     setup_environment
 
-    cd $ROOT/tests
+    cd "$ROOT/tests"
 
     local exitcode=0
 

--- a/tests/cd_command_test.sh
+++ b/tests/cd_command_test.sh
@@ -1,4 +1,4 @@
-set -uo pipefail
+set -u
 
 oneTimeSetUp() {
     # This runs in a subshell (subprocess).

--- a/tests/create_command_test.sh
+++ b/tests/create_command_test.sh
@@ -1,4 +1,4 @@
-set -uo pipefail
+set -u
 
 oneTimeSetUp() {
     # This runs in a subshell (subprocess).

--- a/tests/custom_commands_test.sh
+++ b/tests/custom_commands_test.sh
@@ -1,4 +1,4 @@
-set -uo pipefail
+set -u
 
 oneTimeSetUp() {
     eval "$(dad --shell-init)"

--- a/tests/custom_commands_test.sh
+++ b/tests/custom_commands_test.sh
@@ -29,7 +29,7 @@ testSimple() {
 }
 
 testArguments() {
-    local output=$(dad echo ARG1 ARG2)
+    output=$(dad echo ARG1 ARG2)
 
     assertEquals "command called with arguments" "PREFIX ARG1 ARG2" "$output"
 }

--- a/tests/root_command_test.sh
+++ b/tests/root_command_test.sh
@@ -1,4 +1,4 @@
-set -uo pipefail
+set -u
 
 oneTimeSetUp() {
     eval "$(dad --shell-init)"

--- a/tests/root_command_test.sh
+++ b/tests/root_command_test.sh
@@ -14,13 +14,11 @@ YAML
 }
 
 testDadUsage() {
-    output=$(dad)
+    output=$(dad | head -n1)
     rc=$?
-
-    lines=(${output[@]})
-
     assertEquals "dad command returns zero" 0 $rc
-    assertEquals "dad command output the usage message" "Usage:" "${lines[0]}"
+
+    assertEquals "dad command output the usage message" "Usage:" "${output}"
 }
 
 testDadVersion() {

--- a/tests/up_command_test.sh
+++ b/tests/up_command_test.sh
@@ -1,4 +1,4 @@
-set -uo pipefail
+set -u
 
 oneTimeSetUp() {
     eval "$(dad --shell-init)"

--- a/tests/up_custom_command_test.sh
+++ b/tests/up_custom_command_test.sh
@@ -1,4 +1,4 @@
-set -uo pipefail
+set -u
 
 oneTimeSetUp() {
     eval "$(dad --shell-init)"

--- a/tests/up_go_command_test.sh
+++ b/tests/up_go_command_test.sh
@@ -1,4 +1,4 @@
-set -uo pipefail
+set -u
 
 oneTimeSetUp() {
     eval "$(dad --shell-init)"

--- a/tests/up_python_command_test.sh
+++ b/tests/up_python_command_test.sh
@@ -1,4 +1,4 @@
-set -uo pipefail
+set -u
 
 oneTimeSetUp() {
     eval "$(dad --shell-init)"


### PR DESCRIPTION
## Why

In order to start supporting Zsh, we need to adapt the integration tests.

## How

- improve `script/integration_test` to run on `bash` then on `zsh`

Parent: #68 