### PR TITLE
Add a new task for Go Dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Python:
 
 Go:
 - Go (version): **working**
-- Dep (support for [Go Dep](https://github.com/golang/dep)): **planned**
+- Dep (support for [Go Dep](https://github.com/golang/dep)): **simple**
 
 Others
 - Custom (conditional shell command): **working**
@@ -98,6 +98,7 @@ type dad > /dev/null 2> /dev/null && eval "$(dad --shell-init --with-completion)
 ```yaml
 up:
   - go: 1.9.2
+  - golang_dep
   - python: 3.6.4rc1
   - pip:
     - requirements.txt

--- a/dev.yml
+++ b/dev.yml
@@ -1,8 +1,6 @@
 up:
   - go: 1.10.1
-  - custom:
-      met?: dep status 2> /dev/null > /dev/null
-      meet: dep ensure
+  - golang_dep
   - custom:
       met?: test -e /usr/local/Cellar/shellcheck
       meet: brew install shellcheck

--- a/pkg/tasks/golang_dep.go
+++ b/pkg/tasks/golang_dep.go
@@ -1,0 +1,107 @@
+package tasks
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func init() {
+	allTasks["golang_dep"] = newGolangDep
+}
+
+// GolangDep task manage the Go dependencies with Go Dep
+type GolangDep struct {
+}
+
+func newGolangDep(config *taskConfig) (Task, error) {
+	return &GolangDep{}, nil
+}
+
+func (d *GolangDep) name() string {
+	return "Go Dep"
+}
+
+func (d *GolangDep) header() string {
+	return "dep ensure"
+}
+
+func (d *GolangDep) preRunValidation(ctx *context) (err error) {
+	_, hasFeature := ctx.features["golang"]
+	if !hasFeature {
+		return fmt.Errorf("You must specify a Go environment to use this task")
+	}
+	return nil
+}
+
+func (d *GolangDep) actions(ctx *context) []taskAction {
+	return []taskAction{
+		&golangDepInstall{},
+		&golangDepEnsure{},
+	}
+}
+
+type golangDepInstall struct {
+}
+
+func (p *golangDepInstall) description() string {
+	return "Install Go Dep"
+}
+
+func (p *golangDepInstall) needed(ctx *context) (bool, error) {
+	_, err := exec.LookPath("dep") // Just check if `dep` is in the PATH for now
+	return err != nil, nil
+}
+
+func (p *golangDepInstall) run(ctx *context) error {
+	code, err := runCommand(ctx, "go", "get", "-u", "github.com/golang/dep/cmd/dep")
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		return fmt.Errorf("failed to install Go GolangDep. exit code: %d", code)
+	}
+	return nil
+}
+
+type golangDepEnsure struct {
+}
+
+func (p *golangDepEnsure) description() string {
+	return "Run dep ensure"
+}
+
+func (p *golangDepEnsure) needed(ctx *context) (bool, error) {
+	if !fileExists(ctx, "vendor") {
+		return true, nil
+	}
+
+	// Is the vendor dir out dated?
+	vendorMod, err := fileModTime(ctx, "vendor")
+	if err != nil {
+		return false, err
+	}
+	tomlMod, err := fileModTime(ctx, "Gopkg.toml")
+	if err != nil {
+		return false, err
+	}
+	lockMod, err := fileModTime(ctx, "Gopkg.lock")
+	if err != nil {
+		return false, err
+	}
+	if tomlMod > vendorMod || lockMod > vendorMod {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (p *golangDepEnsure) run(ctx *context) error {
+	code, err := runCommand(ctx, "dep", "ensure")
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		return fmt.Errorf("failed to run dep ensure. exit code: %d", code)
+	}
+	return nil
+}

--- a/pkg/tasks/helper.go
+++ b/pkg/tasks/helper.go
@@ -2,6 +2,8 @@ package tasks
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 
 	"github.com/pior/dad/pkg/executor"
 )
@@ -27,4 +29,19 @@ func runCommand(ctx *context, program string, args ...string) (int, error) {
 
 func runShellSilent(ctx *context, cmdline string) (int, error) {
 	return executor.NewShell(cmdline).SetCwd(ctx.proj.Path).SetEnv(ctx.env.Environ()).Run()
+}
+
+func fileExists(ctx *context, path string) bool {
+	if _, err := os.Stat(filepath.Join(ctx.proj.Path, path)); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+func fileModTime(ctx *context, path string) (int64, error) {
+	s, err := os.Stat(filepath.Join(ctx.proj.Path, path))
+	if err != nil {
+		return 0, err
+	}
+	return s.ModTime().UnixNano(), nil
 }


### PR DESCRIPTION
## Why

The task `golang_dep` is pretty relevant for any Go project.

## How

- install `dep` with `go get -u` if the command is not in the PATH
- check if the vendor dir is outdated based on `mtime` only (too simple?)
- simply run `dep ensure`

## Notes

- The run condition is pretty simplistic, let's start with that. 