### PR TITLE
Add a simple inspect command

### DIFF
--- a/pkg/cmd/inspect.go
+++ b/pkg/cmd/inspect.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pior/dad/pkg/tasks"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pior/dad/pkg/project"
+)
+
+var inspectCmd = &cobra.Command{
+	Use:   "inspect",
+	Short: "Inspect the project and its tasks",
+	Run:   inspectRun,
+	Args:  noArgs,
+}
+
+func inspectRun(cmd *cobra.Command, args []string) {
+	proj, err := project.FindCurrent()
+	checkError(err)
+
+	fmt.Printf("Found project at %s\n", proj.Path)
+	fmt.Printf("Manifest: %s\n", proj.Manifest.Path)
+
+	projectTasks, err := tasks.GetTasksFromProject(proj)
+	checkError(err)
+
+	fmt.Print(tasks.InspectTasks(projectTasks, proj))
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -30,6 +30,7 @@ func build(version string) {
 	rootCmd.AddCommand(createCmd)
 	rootCmd.AddCommand(upCmd)
 	rootCmd.AddCommand(upgradeCmd)
+	rootCmd.AddCommand(inspectCmd)
 }
 
 func rootRun(cmd *cobra.Command, args []string) {

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -1,6 +1,8 @@
 package tasks
 
 import (
+	"fmt"
+
 	"github.com/pior/dad/pkg/project"
 )
 
@@ -52,6 +54,18 @@ func GetFeaturesFromTasks(proj *project.Project, tasks []Task) map[string]string
 	}
 
 	return features
+}
+
+func InspectTasks(taskList []Task, proj *project.Project) (s string) {
+	for _, task := range taskList {
+		s += fmt.Sprintf("Task %s\n", task.name())
+		s += fmt.Sprintf("  Internal: %+v\n", task)
+		if t, ok := task.(TaskWithFeature); ok {
+			featureName, featureVersion := t.feature(proj)
+			s += fmt.Sprintf("  Feature: %s=%s\n", featureName, featureVersion)
+		}
+	}
+	return s
 }
 
 func buildFromDefinition(definition interface{}) (task Task, err error) {

--- a/tests/inspect_command_test.sh
+++ b/tests/inspect_command_test.sh
@@ -1,0 +1,32 @@
+set -u
+
+oneTimeSetUp() {
+    eval "$(dad --shell-init)"
+}
+
+setUp() {
+    cd $SHUNIT_TMPDIR
+    rm -f dev.yml
+}
+
+testWithManifest() {
+    cat > dev.yml <<YAML
+up:
+  - python: 3.6.3
+  - pip: [requirements.txt]
+YAML
+
+    output=$(dad inspect)
+    rc=$?
+    assertEquals "command failed" 0 $rc
+}
+
+testWithouthManifest() {
+    output=$(dad inspect)
+    rc=$?
+    assertEquals "command didn't fail" 1 $rc
+}
+
+
+SHUNIT_PARENT=$0
+. ./shunit2.sh


### PR DESCRIPTION
## Why

Being able to inspect what `dad` sees from the project would be pretty cool.
Nice for debugging. But also when updating `dev.yml`?

## How

Print internals

```
$ dad inspect
Found project at /Users/pior/src/github.com/pior/dad
Manifest: /Users/pior/src/github.com/pior/dad/dev.yml
Task Golang
  Internal: &{version:1.10.1}
  Feature: golang=1.10.1
Task Custom
  Internal: &{condition:dep status 2> /dev/null > /dev/null command:dep ensure}
Task Custom
  Internal: &{condition:test -e /usr/local/Cellar/shellcheck command:brew install shellcheck}
```
