### PR TITLE
Remove a lot of boilerplate code that was handling the exit code

### DIFF
--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -35,15 +35,7 @@ func customCommandRun(cmd *cobra.Command, args []string) error {
 
 	ui.CommandHeader(cmdline)
 
-	code, err := executor.NewShell(cmdline).SetCwd(proj.Path).Run()
-	if err != nil {
-		return fmt.Errorf("command failed: %s", err)
-	}
-	if code != 0 {
-		return fmt.Errorf("command failed with code %d", code)
-	}
-
-	return nil
+	return executor.NewShell(cmdline).SetCwd(proj.Path).Run()
 }
 
 func buildCustomCommands() {

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -48,15 +49,30 @@ func (e *Executor) getExitCode(err error) (int, error) {
 	return -1, err
 }
 
-// Run executes the command and returns the exit code
-func (e *Executor) Run() (int, error) {
+// RunWithCode executes the command. Return the exit code and an error.
+func (e *Executor) RunWithCode() (int, error) {
 	e.cmd.Stdin = os.Stdin
 	e.cmd.Stdout = os.Stdout
 	e.cmd.Stderr = os.Stderr
 
 	err := e.cmd.Run()
 	code, err := e.getExitCode(err)
+	if err != nil {
+		return code, fmt.Errorf("command failed with: %s", err)
+	}
 	return code, err
+}
+
+// Run executes the command. Return an error for non-zero exitcode.
+func (e *Executor) Run() error {
+	code, err := e.RunWithCode()
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		return fmt.Errorf("command failed with exit code %d", code)
+	}
+	return nil
 }
 
 // Capture executes the command and return the output and the exit code

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -6,29 +6,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCommandFalseWithoutCode(t *testing.T) {
+	err := New("false").Run()
+
+	require.Error(t, err)
+}
+
 func TestCommandFalse(t *testing.T) {
-	code, err := New("false").Run()
+	code, err := New("false").RunWithCode()
 
 	require.NoError(t, err)
 	require.Equal(t, 1, code)
 }
 
 func TestCommandTrue(t *testing.T) {
-	code, err := New("true").Run()
+	code, err := New("true").RunWithCode()
 
 	require.NoError(t, err)
 	require.Equal(t, 0, code)
 }
 
 func TestShellTrue(t *testing.T) {
-	code, err := NewShell("true").Run()
+	code, err := NewShell("true").RunWithCode()
 
 	require.NoError(t, err)
 	require.Equal(t, 0, code)
 }
 
 func TestShellFalse(t *testing.T) {
-	code, err := NewShell("false").Run()
+	code, err := NewShell("false").RunWithCode()
 
 	require.NoError(t, err)
 	require.Equal(t, 1, code)
@@ -59,7 +65,7 @@ func TestShellCapturePWD(t *testing.T) {
 }
 
 func TestCommandNotFound(t *testing.T) {
-	code, err := New("never-ever-cmd").Run()
+	code, err := New("never-ever-cmd").RunWithCode()
 
 	require.Error(t, err)
 	require.Equal(t, -1, code)

--- a/pkg/helpers/golang.go
+++ b/pkg/helpers/golang.go
@@ -63,9 +63,9 @@ func (g *Golang) Install() (err error) {
 		return
 	}
 
-	code, err := executor.New("tar", "--strip", "1", "-xzC", g.path, "-f", tarPath).Run()
-	if err != nil || code != 0 {
-		return fmt.Errorf("failed to extract %s to %s (code: %d err: %s)", tarPath, g.path, code, err)
+	err = executor.New("tar", "--strip", "1", "-xzC", g.path, "-f", tarPath).Run()
+	if err != nil {
+		return fmt.Errorf("failed to extract %s to %s: %s", tarPath, g.path, err)
 	}
 
 	return nil

--- a/pkg/helpers/upgrader.go
+++ b/pkg/helpers/upgrader.go
@@ -71,8 +71,7 @@ func (u *Upgrader) Perform(destinationPath string, sourceURL string) (err error)
 
 	u.ui.CommandHeader(cmdline)
 
-	_, err = executor.NewShell(cmdline).Run()
-	return
+	return executor.NewShell(cmdline).Run()
 }
 
 // LatestRelease get latest release item for current platform

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -79,8 +79,7 @@ func (p *Project) Clone() (err error) {
 		return
 	}
 
-	_, err = executor.New("git", "clone", url, p.Path).Run()
-	return
+	return executor.New("git", "clone", url, p.Path).Run()
 }
 
 func (p *Project) Create() (err error) {

--- a/pkg/tasks/custom.go
+++ b/pkg/tasks/custom.go
@@ -64,7 +64,7 @@ func (c *customAction) description() string {
 }
 
 func (c *customAction) needed(ctx *context) (bool, error) {
-	code, err := runShellSilent(ctx, c.condition)
+	code, err := runShellSilentWithCode(ctx, c.condition)
 	if err != nil {
 		return false, fmt.Errorf("failed to run the condition command: %s", err)
 	}
@@ -72,12 +72,9 @@ func (c *customAction) needed(ctx *context) (bool, error) {
 }
 
 func (c *customAction) run(ctx *context) error {
-	code, err := runShellSilent(ctx, c.command)
+	err := runShellSilent(ctx, c.command)
 	if err != nil {
 		return fmt.Errorf("command failed: %s", err)
-	}
-	if code != 0 {
-		return fmt.Errorf("command exited with code %d", code)
 	}
 	return nil
 }

--- a/pkg/tasks/golang_dep.go
+++ b/pkg/tasks/golang_dep.go
@@ -53,12 +53,9 @@ func (p *golangDepInstall) needed(ctx *context) (bool, error) {
 }
 
 func (p *golangDepInstall) run(ctx *context) error {
-	code, err := runCommand(ctx, "go", "get", "-u", "github.com/golang/dep/cmd/dep")
+	err := runCommand(ctx, "go", "get", "-u", "github.com/golang/dep/cmd/dep")
 	if err != nil {
-		return err
-	}
-	if code != 0 {
-		return fmt.Errorf("failed to install Go GolangDep. exit code: %d", code)
+		return fmt.Errorf("failed to install Go GolangDep: %s", err)
 	}
 	return nil
 }
@@ -96,12 +93,9 @@ func (p *golangDepEnsure) needed(ctx *context) (bool, error) {
 }
 
 func (p *golangDepEnsure) run(ctx *context) error {
-	code, err := runCommand(ctx, "dep", "ensure")
+	err := runCommand(ctx, "dep", "ensure")
 	if err != nil {
-		return err
-	}
-	if code != 0 {
-		return fmt.Errorf("failed to run dep ensure. exit code: %d", code)
+		return fmt.Errorf("failed to run dep ensure: %s", err)
 	}
 	return nil
 }

--- a/pkg/tasks/helper.go
+++ b/pkg/tasks/helper.go
@@ -22,13 +22,17 @@ func asString(value interface{}) (string, error) {
 	return "", errors.New("not a string")
 }
 
-func runCommand(ctx *context, program string, args ...string) (int, error) {
+func runCommand(ctx *context, program string, args ...string) error {
 	ctx.ui.TaskCommand(program, args...)
 	return executor.New(program, args...).SetCwd(ctx.proj.Path).SetEnv(ctx.env.Environ()).Run()
 }
 
-func runShellSilent(ctx *context, cmdline string) (int, error) {
+func runShellSilent(ctx *context, cmdline string) error {
 	return executor.NewShell(cmdline).SetCwd(ctx.proj.Path).SetEnv(ctx.env.Environ()).Run()
+}
+
+func runShellSilentWithCode(ctx *context, cmdline string) (int, error) {
+	return executor.NewShell(cmdline).SetCwd(ctx.proj.Path).SetEnv(ctx.env.Environ()).RunWithCode()
 }
 
 func fileExists(ctx *context, path string) bool {

--- a/pkg/tasks/pip.go
+++ b/pkg/tasks/pip.go
@@ -66,12 +66,9 @@ func (p *pipInstall) needed(ctx *context) (bool, error) {
 }
 
 func (p *pipInstall) run(ctx *context) error {
-	code, err := runCommand(ctx, "pip", "install", "--require-virtualenv", "-r", p.file)
+	err := runCommand(ctx, "pip", "install", "--require-virtualenv", "-r", p.file)
 	if err != nil {
-		return err
-	}
-	if code != 0 {
-		return fmt.Errorf("Pip failed with code %d", code)
+		return fmt.Errorf("Pip failed: %s", err)
 	}
 	p.success = true
 	return nil

--- a/pkg/tasks/pipfile.go
+++ b/pkg/tasks/pipfile.go
@@ -56,12 +56,9 @@ func (p *pipfileInstall) needed(ctx *context) (bool, error) {
 }
 
 func (p *pipfileInstall) run(ctx *context) error {
-	code, err := runCommand(ctx, "pip", "install", "--require-virtualenv", "pipenv")
+	err := runCommand(ctx, "pip", "install", "--require-virtualenv", "pipenv")
 	if err != nil {
-		return err
-	}
-	if code != 0 {
-		return fmt.Errorf("failed to install pipenv. exit code: %d", code)
+		return fmt.Errorf("failed to install pipenv: %s", err)
 	}
 	return nil
 }
@@ -79,12 +76,9 @@ func (p *pipfileRun) needed(ctx *context) (bool, error) {
 }
 
 func (p *pipfileRun) run(ctx *context) error {
-	code, err := runCommand(ctx, "pipenv", "install", "--system", "--dev")
+	err := runCommand(ctx, "pipenv", "install", "--system", "--dev")
 	if err != nil {
-		return err
-	}
-	if code != 0 {
-		return fmt.Errorf("pipenv failed with exit code: %d", code)
+		return fmt.Errorf("pipenv failed: %s", err)
 	}
 	p.success = true
 	return nil

--- a/pkg/tasks/python.go
+++ b/pkg/tasks/python.go
@@ -71,12 +71,9 @@ func (p *pythonPyenv) needed(ctx *context) (bool, error) {
 }
 
 func (p *pythonPyenv) run(ctx *context) error {
-	code, err := runCommand(ctx, "pyenv", "install", p.version)
+	err := runCommand(ctx, "pyenv", "install", p.version)
 	if err != nil {
-		return err
-	}
-	if code != 0 {
-		return fmt.Errorf("failed to install the required python version. exit code: %d", code)
+		return fmt.Errorf("failed to install the required python version: %s", err)
 	}
 	return nil
 }
@@ -96,12 +93,9 @@ func (p *pythonInstallVenv) needed(ctx *context) (bool, error) {
 }
 
 func (p *pythonInstallVenv) run(ctx *context) error {
-	code, err := runCommand(ctx, p.pyEnv.Which(p.version, "python"), "-m", "pip", "install", "virtualenv")
+	err := runCommand(ctx, p.pyEnv.Which(p.version, "python"), "-m", "pip", "install", "virtualenv")
 	if err != nil {
-		return err
-	}
-	if code != 0 {
-		return fmt.Errorf("failed to install virtualenv. exit code: %d", code)
+		return fmt.Errorf("failed to install virtualenv: %s", err)
 	}
 
 	return nil
@@ -127,12 +121,9 @@ func (p *pythonCreateVenv) run(ctx *context) error {
 		return err
 	}
 
-	code, err := runCommand(ctx, p.pyEnv.Which(p.version, "virtualenv"), p.venv.Path())
+	err = runCommand(ctx, p.pyEnv.Which(p.version, "virtualenv"), p.venv.Path())
 	if err != nil {
-		return err
-	}
-	if code != 0 {
-		return fmt.Errorf("failed to create the virtualenv. exit code: %d", code)
+		return fmt.Errorf("failed to create the virtualenv: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Why

The executor `Run()` is returning the error AND an exit code (as int). 
It's needed in some cases, but not often.
In most cases, it makes the error handling more complex than needed.

## How

- Change `Run()` to return an error when the code is non-zero
- Add a `RunWithCode()` method returning `(code, error)`
