### PR TITLE
Remove the exit code from the Executor.Capture() response

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -137,14 +137,13 @@ func (e *Executor) Run() error {
 }
 
 // Capture executes the command and return the output and the exit code
-func (e *Executor) Capture() (string, int, error) {
+func (e *Executor) Capture() (string, error) {
 	output, err := e.cmd.Output()
-	code, err := e.getExitCode(err)
-	return string(output), code, err
+	return string(output), err
 }
 
 // CaptureAndTrim calls Capture() and trim the blank lines
-func (e *Executor) CaptureAndTrim() (string, int, error) {
-	output, code, err := e.Capture()
-	return strings.Trim(output, "\n"), code, err
+func (e *Executor) CaptureAndTrim() (string, error) {
+	output, err := e.Capture()
+	return strings.Trim(output, "\n"), err
 }

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -42,26 +42,23 @@ func TestShellFalse(t *testing.T) {
 }
 
 func TestShellCapture(t *testing.T) {
-	output, code, err := NewShell("echo poipoi").Capture()
+	output, err := NewShell("echo poipoi").Capture()
 
 	require.NoError(t, err)
-	require.Zero(t, code)
 	require.Equal(t, "poipoi\n", output)
 }
 
 func TestShellCaptureAndTrim(t *testing.T) {
-	output, code, err := NewShell("echo poipoi").CaptureAndTrim()
+	output, err := NewShell("echo poipoi").CaptureAndTrim()
 
 	require.NoError(t, err)
-	require.Zero(t, code)
 	require.Equal(t, "poipoi", output)
 }
 
 func TestShellCapturePWD(t *testing.T) {
-	output, code, err := NewShell("echo $PWD").SetCwd("/bin").Capture()
+	output, err := NewShell("echo $PWD").SetCwd("/bin").Capture()
 
 	require.NoError(t, err)
-	require.Zero(t, code)
 	require.Equal(t, "/bin\n", output)
 }
 
@@ -73,10 +70,9 @@ func TestCommandNotFound(t *testing.T) {
 }
 
 func TestSetEnv(t *testing.T) {
-	output, code, err := NewShell("echo $POIPOI").SetEnv([]string{"POIPOI=something"}).Capture()
+	output, err := NewShell("echo $POIPOI").SetEnv([]string{"POIPOI=something"}).Capture()
 
 	require.NoError(t, err)
-	require.Zero(t, code)
 	require.Equal(t, "something\n", output)
 }
 

--- a/pkg/helpers/pyenv.go
+++ b/pkg/helpers/pyenv.go
@@ -14,12 +14,9 @@ type PyEnv struct {
 }
 
 func NewPyEnv(cfg *config.Config) (*PyEnv, error) {
-	root, code, err := executor.New("pyenv", "root").CaptureAndTrim()
+	root, err := executor.New("pyenv", "root").CaptureAndTrim()
 	if err != nil {
-		return nil, err
-	}
-	if code != 0 {
-		return nil, fmt.Errorf("Command 'pyenv root' failed with code %d", code)
+		return nil, fmt.Errorf("Command 'pyenv root' failed: %s", err)
 	}
 	v := PyEnv{root: root}
 	return &v, nil
@@ -40,12 +37,9 @@ func (p *PyEnv) VersionInstalled(version string) (installed bool, err error) {
 }
 
 func (p *PyEnv) listVersions() ([]string, error) {
-	output, code, err := executor.New("pyenv", "versions", "--bare", "--skip-aliases").Capture()
+	output, err := executor.New("pyenv", "versions", "--bare", "--skip-aliases").Capture()
 	if err != nil {
-		return nil, err
-	}
-	if code != 0 {
-		return nil, fmt.Errorf("failed to run pyenv versions. exit code: %d", code)
+		return nil, fmt.Errorf("failed to run pyenv versions: %s", err)
 	}
 
 	versions := strings.Split(strings.TrimSpace(output), "\n")


### PR DESCRIPTION
## Why

Having the exit code AND the error makes the error handling harder than needed.

## How


