### PR TITLE
[FEATURE] Support for project links in the open command

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -51,3 +51,6 @@ commands:
       [ -e "/usr/local/bin/dad" ] && sudo rm -v /usr/local/bin/dad
       [ -e "$GOPATH/bin/dad" ] && sudo rm -v $GOPATH/bin/dad
       bash -c "$(curl -sL https://raw.githubusercontent.com/pior/dad/master/install.sh)"
+
+open:
+  milestone: https://github.com/pior/dad/milestone/1

--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -28,7 +28,11 @@ func openRun(cmd *cobra.Command, args []string) {
 	case "pullrequest", "pr":
 		url, err = helpers.NewGitRepo(proj.Path).BuildGithubPullrequestURL()
 	default:
-		err = fmt.Errorf("I don't know how to open %s", args[0])
+		url = proj.Manifest.Open[args[0]]
+		if url != "" {
+			break
+		}
+		err = fmt.Errorf("no link for '%s'", args[0])
 	}
 	checkError(err)
 	if url != "" {

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -17,8 +17,9 @@ type Manifest struct {
 }
 
 type Content struct {
-	Up       []interface{}      `yaml:"up"`
-	Commands map[string]Command `yaml:"commands"`
+	Up       []interface{}       `yaml:"up"`
+	Commands map[string]*Command `yaml:"commands"`
+	Open     map[string]string   `yaml:"open"`
 }
 
 type Command struct {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -14,6 +14,14 @@ var manifestContent = []byte(`
 up:
   - task1
   - task2
+
+commands:
+  cmd1:
+    desc: description1
+    run: command1
+
+open:
+  app: http://localhost:5000
 `)
 
 func createManifest(dir string) {
@@ -33,5 +41,8 @@ func TestLoad(t *testing.T) {
 	man, err := Load(dir)
 	require.NoError(t, err, "Load() failed")
 	require.NotEqual(t, nil, man)
+
 	require.Equal(t, []interface{}{"task1", "task2"}, man.Up)
+	require.Equal(t, map[string]*Command{"cmd1": &Command{Run: "command1", Description: "description1"}}, man.Commands)
+	require.Equal(t, map[string]string{"app": "http://localhost:5000"}, man.Open)
 }


### PR DESCRIPTION
## Why

Implement the second part of the `dad open <nam>` command: project links.

## How

- Basic lookup for now (fuzzy search should be added pretty soon)
- No tests for now, the fuzzy search will require a small refacto that will let us add proper testing.

dev.yml:
```yaml
open:
  name: <link>
```

